### PR TITLE
Fix carry box toggle and clean up animation state

### DIFF
--- a/BasicAnimations/Animations.cs
+++ b/BasicAnimations/Animations.cs
@@ -46,17 +46,22 @@ internal static class Animations
     {
         try
         {
-            if (IsAnimationActive && CheckRequirements())
+            if (IsAnimationActive)
             {
                 MainPlayer.Tasks.Clear();
                 Box.Detach();
                 GameFiber.Wait(1);
                 Box.Position = new Vector3(0f, 0f, 0f);
                 IsAnimationActive = false;
+                return;
             }
-            // 0x6B9BBD38AB0796DF ATTACH_ENTITY_TO_ENTITY
-            if (IsAnimationActive || !CheckRequirements()) return;
-            if (!Box.Exists()) { Box = new Rage.Object(new Model("prop_cs_cardbox_01"), Vector3.Zero, 0f); }
+
+            if (!CheckRequirements()) return;
+
+            if (!Box.Exists())
+            {
+                Box = new Rage.Object(new Model("prop_cs_cardbox_01"), Vector3.Zero, 0f);
+            }
             else if (Box.Exists())
             {
                 MainPlayer.Tasks.PlayAnimation(new AnimationDictionary("anim@heists@box_carry@"), "idle", 5f,

--- a/BasicAnimations/Systems/Helper.cs
+++ b/BasicAnimations/Systems/Helper.cs
@@ -34,6 +34,5 @@ internal class Helper
         }
         GameFiber.Wait(1);
         IsAnimationActive = false;
-        IsAnimationActive = false;
     }
 }


### PR DESCRIPTION
## Summary
- handle carry box animation properly by returning after detaching
- remove redundant IsAnimationActive flag reset

## Testing
- `dotnet build` *(fails: reference assemblies for .NETFramework,Version=v4.7.2 were not found)*
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68915a2686a08323ac62a6966cacbebc